### PR TITLE
Cap sanity

### DIFF
--- a/cice_cap.F90
+++ b/cice_cap.F90
@@ -275,6 +275,16 @@ module cice_cap
       write(6,*)'DMI_CPL: CICE allocated PES: nblocks_tot:',nblocks_tot
       write(6,*)'DMI_CPL: CICE used PES: peIDCount:       ',peIDCount
     endif
+    if (peIDCount /= ice_petCount) then
+      if (me==0) then
+        write(6,*)'DMI_CPL: ERROR: Required CICE peIDCount not equal to requested ice_petCount'
+        write(6,*)'DMI_CPL: TIP:     Adjust ice_petCount in nuopc_nml file'
+      endif
+      call ESMF_LogWrite('DMI_CPL: ERROR: Required CICE peIDCount not equal to requested ice_petCount:', &
+        ESMF_LOGMSG_ERROR, rc=rc)
+      rc = ESMF_RC_OBJ_BAD
+      return
+    endif
     if (peIDCount /= nblocks_tot) then
       if (me==0) then
         write(6,*)'DMI_CPL: ERROR: Required CICE peIDCount not equal to CICE allocated nblocks_tot.'
@@ -285,18 +295,8 @@ module cice_cap
         ESMF_LOGMSG_ERROR, rc=rc)
       rc = ESMF_RC_OBJ_BAD
       return
-    else if (peIDCount /= nblocks_tot) then
-      if (me==0) then
-        write(6,*)'DMI_CPL: ERROR: Required CICE peIDCount not equal to requested ice_petCount'
-        write(6,*)'DMI_CPL: TIP:     Adjust ice_petCount in nuopc_nml file'
-      endif
-      call ESMF_LogWrite('DMI_CPL: ERROR: Required CICE peIDCount not equal to requested ice_petCount:', &
-        ESMF_LOGMSG_ERROR, rc=rc)
-      rc = ESMF_RC_OBJ_BAD
-      return
-    else
-      if (me==0) write(6,*)'DMI_CPL: peIDCount equals requested ice_petCount: OK'
     endif
+    if (me==0) write(6,*)'DMI_CPL: peIDCount equals requested ice_petCount: OK'
 
 !tarnotglobal    allocate(connectionList(2))
     ! bipolar boundary condition at top row: nyg

--- a/esm.F90
+++ b/esm.F90
@@ -99,10 +99,28 @@ module ESM
     ! call namelist coupled
     call nuopc_opt()
 
-    ! SetServices for CICE with petList on first half of PETs
+    ! SetServices for OCN with petList on first half of PETs
+    allocate(petList(ocn_petCount))
+    do i=1,ocn_petCount
+      petList(i)=i-1
+    enddo
+    call NUOPC_DriverAddComp(driver, "HYCOM", ocnSS, petList=petList, &
+      comp=child, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    call NUOPC_CompAttributeSet(child, name="Verbosity", value="high", rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    deallocate(petList)
+
+    ! SetServices for CICE with petList on second half of PETs
      allocate(petList(ice_petCount))
      do i=1,ice_petCount
-        petList(i)=i-1
+        petList(i)=ocn_petCount+i-1
      enddo
     call NUOPC_DriverAddComp(driver, "CICE", iceSS,petList=petList, &
       comp=child, rc=rc) !tar comment not sure why comp needs to be a child
@@ -117,23 +135,7 @@ module ESM
       return  ! bail out
     deallocate(petList)
     
-    ! SetServices for OCN with petList on second half of PETs
-    allocate(petList(ocn_petCount))
-    do i=1,ocn_petCount
-      petList(i)=ice_petCount+i-1
-    enddo
-    call NUOPC_DriverAddComp(driver, "HYCOM", ocnSS, petList=petList, &
-      comp=child, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    call NUOPC_CompAttributeSet(child, name="Verbosity", value="high", rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    deallocate(petList)
+
     ! SetServices for cice2ocn
     call NUOPC_DriverAddComp(driver, srcCompLabel="CICE", dstCompLabel="HYCOM", &
       compSetServicesRoutine=cplSS, comp=connector, rc=rc)

--- a/esm.F90
+++ b/esm.F90
@@ -55,7 +55,7 @@ module ESM
       file=__FILE__)) &
       return  ! bail out
 
-! set verbosity on driver
+    ! set verbosity on driver
     call NUOPC_CompAttributeSet(driver, name="Verbosity", value="max", rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, &
@@ -95,8 +95,10 @@ module ESM
       line=__LINE__, &
       file=__FILE__)) &
       return  ! bail out
-! call namelist coupled
+
+    ! call namelist coupled
     call nuopc_opt()
+
     ! SetServices for CICE with petList on first half of PETs
      allocate(petList(ice_petCount))
      do i=1,ice_petCount
@@ -157,8 +159,8 @@ module ESM
       line=__LINE__, &
       file=__FILE__)) &
       return  ! bail out
+
     ! set the driver clock
-!    call nuopc_opt()
     call ESMF_TimeIntervalSet(timeStep, s=nuopc_tinterval, rc=rc) ! 3 minute steps
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, &

--- a/hycom_cap.F90
+++ b/hycom_cap.F90
@@ -408,8 +408,6 @@ module hycom_cap
       file=__FILE__)) &
       return  ! bail out
 
-    if (me==0) print *,"DMI_CPL: HYCOM ModelAdvance started"
-
     if (profile_memory) call ESMF_VMLogMemInfo("Entering HYCOM Model_ADVANCE: ", rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, &


### PR DESCRIPTION
* Remove print to stdout in hycom_cap for every model advance
* Change printout to stdout + add extra check on ice_petCount==nblocks_tot. Unsure if it is necessary.
* Minor code cleanup without changing the code.
* Changed allocation order. Now first HYCOM, then CICE, because HYCOM is easier to fil up the entire pes on each node(s).