### PR TITLE
Add ocean energy to move tmxl towards tfrz (only if tmxl < tfrz)

### DIFF
--- a/hycom_cap.F90
+++ b/hycom_cap.F90
@@ -8,6 +8,7 @@ module hycom_cap
     end_of_run, end_of_run_cpl
 
   use mod_hycom_nuopc_glue
+  use mod_dimensions, only : idm,jdm,nbdy
   use mod_cb_arrays_nuopc_glue
   use mod_nuopc_options, only: esmf_write_diagnostics, nuopc_restart, profile_memory, nuopc_tinterval
   use ESMF
@@ -45,13 +46,15 @@ module hycom_cap
     real(ESMF_KIND_R8), dimension(:,:,:), pointer :: farrayPtr
   end type fld_list_type
 
-  integer,parameter :: fldsMax = 50
-  integer :: fldsToOcn_num = 0
+  integer,parameter    :: fldsMax = 50
+  integer              :: fldsToOcn_num = 0
   type (fld_list_type) :: fldsToOcn(fldsMax)
-  integer :: fldsFrOcn_num = 0
+  integer              :: fldsFrOcn_num = 0
   type (fld_list_type) :: fldsFrOcn(fldsMax)
-  character(len=2048):: info
-  real(ESMF_KIND_R8)          :: ocn_cpl_frq
+  character(len=2048)  :: info
+  real(ESMF_KIND_R8)   :: ocn_cpl_frq
+
+  real, save, allocatable, dimension(:,:) :: si_sice
 
   !-----------------------------------------------------------------------------
   contains
@@ -219,6 +222,10 @@ module hycom_cap
     endif
 
     if (me==0) print *,"DMI_CPL: HYCOM_INIT finished"
+
+    ! Ice salinity
+    allocate( si_sice(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) )
+    si_sice=0.0  ! Initial setting and allocate memory space
 
     ! set Component name so it becomes identifiable
 #ifdef TARNOTNEEDED
@@ -640,7 +647,8 @@ module hycom_cap
     real(8) :: xstress, ystress, pang_rev
     real(ESMF_KIND_R8), pointer :: dataPtr_sic(:,:),  dataPtr_sit(:,:),  dataPtr_sitx(:,:), &
                                    dataPtr_sity(:,:), dataPtr_siqs(:,:), dataPtr_sifs(:,:), &
-                                   dataPtr_sih(:,:),  dataPtr_sifw(:,:), dataPtr_sifh(:,:)
+                                   dataPtr_sih(:,:),  dataPtr_sifw(:,:), dataPtr_sifh(:,:), &
+                                   dataPtr_sice(:,:)
     call state_getFldPtr(st,"sea_ice_fraction",dataPtr_sic,rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) return
     call state_getFldPtr(st,"sea_ice_temperature",dataPtr_sit,rc=rc)  
@@ -658,6 +666,8 @@ module hycom_cap
     call state_getFldPtr(st,"mean_fresh_water_to_ocean_rate",dataPtr_sifw,rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) return
     call state_getFldPtr(st,"net_heat_flx_to_ocn",dataPtr_sifh,rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) return
+    call state_getFldPtr(st,"ice_salinity",dataPtr_sice,rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) return
 
 !NOT SURE ABOUT THESE FOUR. At least siu and siv should be used.
@@ -690,6 +700,7 @@ module hycom_cap
             si_t  (i,j) =  dataPtr_sit(i,j)  !Sea Ice Temperature
             thkice(i,j) =  dataPtr_sih(i,j)  !Sea Ice Thickness
             si_h  (i,j) =  dataPtr_sih(i,j)  !Sea Ice Thickness
+            si_sice(i,j)=  dataPtr_sice(i,j) !Sea Ice Salinity
           else
             si_tx (i,j) =  0.0 !Sea Ice X-Stress into ocean
             si_ty (i,j) =  0.0 !Sea Ice Y-Stress into ocean
@@ -701,6 +712,7 @@ module hycom_cap
             si_t  (i,j) =  0.0 !Sea Ice Temperature
             thkice(i,j) =  0.0 !Sea Ice Thickness
             si_h  (i,j) =  0.0 !Sea Ice Thickness
+            si_sice(i,j)=  0.0 !Sea Ice Salinity
           endif
          
         enddo
@@ -750,7 +762,7 @@ module hycom_cap
     real(kind=ESMF_KIND_R8), pointer  :: dataPtr_mld(:,:)
 
     integer :: i,j
-    real(kind=ESMF_KIND_R8) :: hfrz, t2f, tfrz, smxl, tmxl, ssfi
+    real(kind=ESMF_KIND_R8) :: hfrz, t2f, tfrz, smxl, tmxl, ssfi, tmlt
     real(kind=ESMF_KIND_R8) :: usur1, usur2, vsur1, vsur2, utot, vtot
     real(kind=ESMF_KIND_R8) :: ssh_n,ssh_s,ssh_e,ssh_w,dhdy
     integer                 :: cplfrq
@@ -773,8 +785,14 @@ module hycom_cap
           dataPtr_sss(i,j) = smxl ! construct SSS
           hfrz = min( thkfrz*onem, dpbl(i,j) )
           t2f  = (spcifh*hfrz)/(baclin*dble(icefrq)*dble(icpfrq)*g)
-          tfrz = tfrz_0 + smxl*tfrz_s  !salinity dependent freezing point
-          ssfi = (tfrz-tmxl)*t2f       !W/m^2 into ocean
+          tfrz = tfrz_0 + smxl*tfrz_s          ! salinity dependent freezing point: HYCOM
+          tmlt = tfrz_0 + si_sice(i,j)*tfrz_s  ! salinity dependent melting point:  CICE
+          ! Modified melt point of sea ice. Old version only contained the else clause
+          if ((tmlt>tfrz) .and. (tmxl>tfrz)) then
+            ssfi = t2f*min(tmlt,tmlt-tmxl)
+          else
+            ssfi = (tfrz-tmxl)*t2f       !W/m^2 into ocean
+          endif
           dataPtr_fmpot(i,j) = max(-1000.0,min(1000.0,ssfi)) ! > 0. freezing potential of flxice
           frzh(i,j)=dataPtr_fmpot(i,j)
         enddo
@@ -826,7 +844,6 @@ module hycom_cap
      else
         do j=1,jja
         do i=1,ii
-
               dataPtr_mld(i,j) = 0.
          enddo
         enddo
@@ -913,6 +930,7 @@ module hycom_cap
    call fld_list_add(fldsToOcn_num,fldsToOcn,"net_heat_flx_to_ocn"           ,"1"  ,"will provide") !
    call fld_list_add(fldsToOcn_num,fldsToOcn,"mean_ice_volume"               ,"1"  ,"will provide")
    call fld_list_add(fldsToOcn_num,fldsToOcn,"mean_snow_volume"              ,"1"  ,"will provide")
+   call fld_list_add(fldsToOcn_num,fldsToOcn,"ice_salinity"                  ,"1"  ,"will provide")
 
   end subroutine HYCOM_FieldsSetup
 

--- a/mod_cb_arrays_nuopc_glue.F90
+++ b/mod_cb_arrays_nuopc_glue.F90
@@ -34,12 +34,12 @@
         public pang           ! ANGLET
         public dhde           ! eastward ssh slope
         public dhdn           ! northward ssh slope
-        public uml           ! eastward u velocity
-        public vml           ! northward v velocity
-        public tml           ! export T average over one coupling sequence
-        public sml           ! export S average over one coupling sequence
+        public uml            ! eastward u velocity
+        public vml            ! northward v velocity
+        public tml            ! export T average over one coupling sequence
+        public sml            ! export S average over one coupling sequence
         public sshm           ! export SSH average over one coupling sequence
-        !public frzh           ! export of freezing and melting potential 
+        public frzh           ! export of freezing and melting potential 
         
         ! native imports
         public covice         ! ice coverage (rel.units)
@@ -63,7 +63,7 @@
         
         ! scalars and flags
         public g, onem, qonem, thkfrz, baclin, spcifh, pcp_fact
-        public tfrz_0, tfrz_s, frzh
+        public tfrz_0, tfrz_s
         public iceflg, icmflg, sstflg,itest,jtest,ltripolar
         
       end module


### PR DESCRIPTION
Depending on the Tmxl vs Tfrz ocean temperature: Adjust flxice:
Tmxl<Tfrz: Add energy to move Tmxl towards Tfrz , ie. sea.ice formation
Tmxl>Tfrz: Add (negative) energy from CICE (fhocn) to lower Tmxl, ie. sea-ice melting

Use ice salinity (sice) for calculating melting temperature Tmlt. If sice do not exist, use Tmlt=0.
This do affect flxice, which is set to 0 for Tfrz<T<Tmlt. 
