### PR TITLE
Enable to run until last forcing field, Pass aice(aice<puny)==0

### DIFF
--- a/cice_cap.F90
+++ b/cice_cap.F90
@@ -20,7 +20,6 @@ module cice_cap
   use ice_flux
   use ice_grid, only: TLAT, TLON, ULAT, ULON, hm, tarea, ANGLET, ANGLE, &
                       dxt, dyt, grid_average_X2Y
-!                      dxt, dyt, t2ugrid_vector
   use icepack_parameters, only: puny
   use ice_state
   use CICE_RunMod

--- a/hycom_cap.F90
+++ b/hycom_cap.F90
@@ -9,7 +9,6 @@ module hycom_cap
 
   use mod_hycom_nuopc_glue
   use mod_dimensions, only : idm,jdm,nbdy
-  use icepack_parameters, only: puny
   use mod_cb_arrays_nuopc_glue
   use mod_nuopc_options, only: esmf_write_diagnostics, nuopc_restart, profile_memory, & 
                                nuopc_tinterval, mushy_frz
@@ -689,9 +688,8 @@ module hycom_cap
         do i=1,ii
           covice(i,j) = dataPtr_sic(i,j) !Sea Ice Concentration
           si_c  (i,j) = dataPtr_sic(i,j) !Sea Ice Concentration
-! CICE use puny as criterium (fewer copy commands). Moreover, if used for final differences, these calculations would be affected differently depending on puny vs. 0.0.
-!          if (covice(i,j)>0.0) then
-          if (covice(i,j)>puny) then
+          ! CICE use puny as criterium for open water. This is handled in cice_cap.F90
+          if (covice(i,j)>0.0) then
             if (frzh(i,j)>0.0) then
               ! --- add energy to move tmxl towards tfrz (only if tmxl < tfrz)
               ! This is all the available for freezing. This has been cell averaged


### PR DESCRIPTION
The following updates has been done:
- Enable to run coupled until very last timestep for forcing data: Added stop_now_cpl to be able to dump last timestep and avoid crashing afterwards.
- Threats aice(aice<puny) as aice=c0, as CICE treats it as open waters. Therefore export aice=c0 where aice<puny
- CICE variable updates: Replace t2ugrid_vector by grid_average_X2Y. Similar strocnxT, strocnyT replaced by strocnxT_iavg, strocnyT_iavg.
-  Add some comments within the code

